### PR TITLE
(new): add v1 rotate keys

### DIFF
--- a/public/.well-known/uhp-integrity-20250809.public.json
+++ b/public/.well-known/uhp-integrity-20250809.public.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "crv": "Ed25519",
+      "x": "lnpLeS9HJcQz-jIQktQmOadFPTw4gOU-MLlJazxEGKA",
+      "kty": "OKP",
+      "alg": "EdDSA",
+      "use": "sig"
+    }
+  ]
+}

--- a/public/.well-known/uhp-signer-20250809.public.json
+++ b/public/.well-known/uhp-signer-20250809.public.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "crv": "Ed25519",
+      "x": "SR7jXWtJ5-Va3PM9KGp1CuF8Z3c4SXQCuOOvttrw8_c",
+      "kty": "OKP",
+      "alg": "EdDSA",
+      "use": "sig"
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces the first public key for the rotate branch, which will be used for key rotation and signing operations within the Uhpenry licensing system.